### PR TITLE
Switch to hyper over rouille

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,40 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
-
-[[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "autocfg"
@@ -78,37 +42,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli"
-version = "3.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -142,34 +75,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
-dependencies = [
- "iana-time-zone",
- "num-integer",
- "num-traits",
- "winapi",
-]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,15 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,60 +107,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deflate"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
-dependencies = [
- "adler32",
- "gzip-header",
 ]
 
 [[package]]
@@ -282,27 +124,6 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
-name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "windows-sys 0.42.0",
-]
 
 [[package]]
 name = "fnv"
@@ -430,15 +251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gzip-header"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
-dependencies = [
- "crc32fast",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,30 +357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,15 +374,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -634,15 +413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,22 +438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,34 +447,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand",
- "safemem",
- "tempfile",
- "twoway",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -739,15 +465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -829,12 +546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,15 +611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,38 +632,13 @@ dependencies = [
  "anyhow",
  "dotenv",
  "futures",
+ "hyper",
  "regex",
- "rouille",
  "tokio",
  "twilight-gateway",
  "twilight-http",
  "twilight-model",
  "twilight-util",
-]
-
-[[package]]
-name = "rouille"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f86e4c51a773f953f02bbab5fd049f004bfd384341d62da2a079aff812ab176"
-dependencies = [
- "base64",
- "brotli",
- "chrono",
- "deflate",
- "filetime",
- "multipart",
- "num_cpus",
- "percent-encoding",
- "rand",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "threadpool",
- "time",
- "tiny_http",
- "url",
 ]
 
 [[package]]
@@ -1004,12 +681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "schannel"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,12 +695,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"
@@ -1128,17 +793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,29 +844,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,22 +864,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -1267,18 +887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
-]
-
-[[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
 ]
 
 [[package]]
@@ -1530,28 +1138,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -1573,12 +1163,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"
@@ -1714,15 +1298,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ twilight-http = { default-features = false, features = ["rustls-native-roots"], 
 twilight-model = "0.14"
 twilight-util = { default-features = false, features = ["builder"], version = "0.14" }
 regex = "1.7.0"
-rouille = "3.6.1"
+hyper = { version = "0.14", features = ["full"] }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,13 +1,23 @@
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+
+async fn ping_health(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    Ok(Response::new("Hello world!".into()))
+}
+
 pub async fn start_server() {
     println!("Starting server..");
 
-    rouille::start_server("0.0.0.0:8080", move |request| {
-        rouille::router!(request,
-            (GET) (/) => {
-                rouille::Response::text("Hello world!")
-            },
+    let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
 
-            _ => rouille::Response::empty_404()
-        )
-    });
+    let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(ping_health)) });
+
+    let server = Server::bind(&addr).serve(make_svc);
+
+    // Run this server for... forever!
+    if let Err(e) = server.await {
+        eprintln!("Server error: {}", e);
+    }
 }


### PR DESCRIPTION
Switches to [hyper.rs](https://hyper.rs/) over rouille.

It should be noted that the server no longer does routing, simply returning `Hello world!` for every request it gets (rather than previously returning a 404).
Errors in the http server are currently unhandled.

<details pre>
<summary>
cargo tree before:
</summary>
<pre><code>
roblox-ts-bot v0.1.0
├── anyhow v1.0.66
├── dotenv v0.15.0
├── futures v0.3.25
│   ├── futures-channel v0.3.25
│   │   ├── futures-core v0.3.25
│   │   └── futures-sink v0.3.25
│   ├── futures-core v0.3.25
│   ├── futures-executor v0.3.25
│   │   ├── futures-core v0.3.25
│   │   ├── futures-task v0.3.25
│   │   └── futures-util v0.3.25
│   │       ├── futures-channel v0.3.25 (*)
│   │       ├── futures-core v0.3.25
│   │       ├── futures-io v0.3.25
│   │       ├── futures-macro v0.3.25 (proc-macro)
│   │       │   ├── proc-macro2 v1.0.47
│   │       │   │   └── unicode-ident v1.0.5
│   │       │   ├── quote v1.0.21
│   │       │   │   └── proc-macro2 v1.0.47 (*)
│   │       │   └── syn v1.0.103
│   │       │       ├── proc-macro2 v1.0.47 (*)
│   │       │       ├── quote v1.0.21 (*)
│   │       │       └── unicode-ident v1.0.5
│   │       ├── futures-sink v0.3.25
│   │       ├── futures-task v0.3.25
│   │       ├── memchr v2.5.0
│   │       ├── pin-project-lite v0.2.9
│   │       ├── pin-utils v0.1.0
│   │       └── slab v0.4.7
│   │           [build-dependencies]
│   │           └── autocfg v1.1.0
│   ├── futures-io v0.3.25
│   ├── futures-sink v0.3.25
│   ├── futures-task v0.3.25
│   └── futures-util v0.3.25 (*)
├── regex v1.7.0
│   ├── aho-corasick v0.7.19
│   │   └── memchr v2.5.0
│   ├── memchr v2.5.0
│   └── regex-syntax v0.6.28
├── rouille v3.6.1
│   ├── base64 v0.13.1
│   ├── brotli v3.3.4
│   │   ├── alloc-no-stdlib v2.0.4
│   │   ├── alloc-stdlib v0.2.2
│   │   │   └── alloc-no-stdlib v2.0.4
│   │   └── brotli-decompressor v2.3.2
│   │       ├── alloc-no-stdlib v2.0.4
│   │       └── alloc-stdlib v0.2.2 (*)
│   ├── chrono v0.4.23
│   │   ├── iana-time-zone v0.1.53
│   │   ├── num-integer v0.1.45
│   │   │   └── num-traits v0.2.15
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.1.0
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.1.0
│   │   └── num-traits v0.2.15 (*)
│   ├── deflate v1.0.0
│   │   ├── adler32 v1.2.0
│   │   └── gzip-header v1.0.0
│   │       └── crc32fast v1.3.2
│   │           └── cfg-if v1.0.0
│   ├── filetime v0.2.18
│   │   ├── cfg-if v1.0.0
│   │   └── libc v0.2.137
│   ├── multipart v0.18.0
│   │   ├── buf_redux v0.8.4
│   │   │   ├── memchr v2.5.0
│   │   │   └── safemem v0.3.3
│   │   ├── httparse v1.8.0
│   │   ├── log v0.4.17
│   │   │   └── cfg-if v1.0.0
│   │   ├── mime v0.3.16
│   │   ├── mime_guess v2.0.4
│   │   │   ├── mime v0.3.16
│   │   │   └── unicase v2.6.0
│   │   │       [build-dependencies]
│   │   │       └── version_check v0.9.4
│   │   │   [build-dependencies]
│   │   │   └── unicase v2.6.0 (*)
│   │   ├── quick-error v1.2.3
│   │   ├── rand v0.8.5
│   │   │   ├── libc v0.2.137
│   │   │   ├── rand_chacha v0.3.1
│   │   │   │   ├── ppv-lite86 v0.2.17
│   │   │   │   └── rand_core v0.6.4
│   │   │   │       └── getrandom v0.2.8
│   │   │   │           ├── cfg-if v1.0.0
│   │   │   │           └── libc v0.2.137
│   │   │   └── rand_core v0.6.4 (*)
│   │   ├── safemem v0.3.3
│   │   ├── tempfile v3.3.0
│   │   │   ├── cfg-if v1.0.0
│   │   │   ├── fastrand v1.8.0
│   │   │   ├── libc v0.2.137
│   │   │   └── remove_dir_all v0.5.3
│   │   └── twoway v0.1.8
│   │       └── memchr v2.5.0
│   ├── num_cpus v1.14.0
│   │   └── libc v0.2.137
│   ├── percent-encoding v2.2.0
│   ├── rand v0.8.5 (*)
│   ├── serde v1.0.147
│   │   └── serde_derive v1.0.147 (proc-macro)
│   │       ├── proc-macro2 v1.0.47 (*)
│   │       ├── quote v1.0.21 (*)
│   │       └── syn v1.0.103 (*)
│   ├── serde_derive v1.0.147 (proc-macro) (*)
│   ├── serde_json v1.0.87
│   │   ├── itoa v1.0.4
│   │   ├── ryu v1.0.11
│   │   └── serde v1.0.147 (*)
│   ├── sha1 v0.10.5
│   │   ├── cfg-if v1.0.0
│   │   ├── cpufeatures v0.2.5
│   │   └── digest v0.10.5
│   │       ├── block-buffer v0.10.3
│   │       │   └── generic-array v0.14.6
│   │       │       └── typenum v1.15.0
│   │       │       [build-dependencies]
│   │       │       └── version_check v0.9.4
│   │       └── crypto-common v0.1.6
│   │           ├── generic-array v0.14.6 (*)
│   │           └── typenum v1.15.0
│   ├── threadpool v1.8.1
│   │   └── num_cpus v1.14.0 (*)
│   ├── time v0.3.17
│   │   ├── libc v0.2.137
│   │   ├── num_threads v0.1.6
│   │   └── time-core v0.1.0
│   ├── tiny_http v0.12.0
│   │   ├── ascii v1.1.0
│   │   ├── chunked_transfer v1.4.0
│   │   ├── httpdate v1.0.2
│   │   └── log v0.4.17 (*)
│   └── url v2.3.1
│       ├── form_urlencoded v1.1.0
│       │   └── percent-encoding v2.2.0
│       ├── idna v0.3.0
│       │   ├── unicode-bidi v0.3.8
│       │   └── unicode-normalization v0.1.22
│       │       └── tinyvec v1.6.0
│       │           └── tinyvec_macros v0.1.0
│       └── percent-encoding v2.2.0
├── tokio v1.21.2
│   ├── bytes v1.2.1
│   ├── libc v0.2.137
│   ├── memchr v2.5.0
│   ├── mio v0.8.5
│   │   ├── libc v0.2.137
│   │   └── log v0.4.17 (*)
│   ├── num_cpus v1.14.0 (*)
│   ├── parking_lot v0.12.1
│   │   ├── lock_api v0.4.9
│   │   │   └── scopeguard v1.1.0
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.1.0
│   │   └── parking_lot_core v0.9.4
│   │       ├── cfg-if v1.0.0
│   │       ├── libc v0.2.137
│   │       └── smallvec v1.10.0
│   ├── pin-project-lite v0.2.9
│   ├── signal-hook-registry v1.4.0
│   │   └── libc v0.2.137
│   ├── socket2 v0.4.7
│   │   └── libc v0.2.137
│   └── tokio-macros v1.8.0 (proc-macro)
│       ├── proc-macro2 v1.0.47 (*)
│       ├── quote v1.0.21 (*)
│       └── syn v1.0.103 (*)
│   [build-dependencies]
│   └── autocfg v1.1.0
├── twilight-gateway v0.14.0
│   ├── bitflags v1.3.2
│   ├── futures-util v0.3.25 (*)
│   ├── leaky-bucket-lite v0.5.2
│   │   └── tokio v1.21.2 (*)
│   ├── rustls v0.20.7
│   │   ├── log v0.4.17 (*)
│   │   ├── ring v0.16.20
│   │   │   ├── libc v0.2.137
│   │   │   ├── once_cell v1.16.0
│   │   │   ├── spin v0.5.2
│   │   │   └── untrusted v0.7.1
│   │   │   [build-dependencies]
│   │   │   └── cc v1.0.76
│   │   ├── sct v0.7.0
│   │   │   ├── ring v0.16.20 (*)
│   │   │   └── untrusted v0.7.1
│   │   └── webpki v0.22.0
│   │       ├── ring v0.16.20 (*)
│   │       └── untrusted v0.7.1
│   ├── rustls-native-certs v0.6.2
│   │   ├── openssl-probe v0.1.5
│   │   └── rustls-pemfile v1.0.1
│   │       └── base64 v0.13.1
│   ├── serde v1.0.147 (*)
│   ├── serde_json v1.0.87 (*)
│   ├── tokio v1.21.2 (*)
│   ├── tokio-tungstenite v0.17.2
│   │   ├── futures-util v0.3.25 (*)
│   │   ├── log v0.4.17 (*)
│   │   ├── rustls v0.20.7 (*)
│   │   ├── rustls-native-certs v0.6.2 (*)
│   │   ├── tokio v1.21.2 (*)
│   │   ├── tokio-rustls v0.23.4
│   │   │   ├── rustls v0.20.7 (*)
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   └── webpki v0.22.0 (*)
│   │   ├── tungstenite v0.17.3
│   │   │   ├── base64 v0.13.1
│   │   │   ├── byteorder v1.4.3
│   │   │   ├── bytes v1.2.1
│   │   │   ├── http v0.2.8
│   │   │   │   ├── bytes v1.2.1
│   │   │   │   ├── fnv v1.0.7
│   │   │   │   └── itoa v1.0.4
│   │   │   ├── httparse v1.8.0
│   │   │   ├── log v0.4.17 (*)
│   │   │   ├── rand v0.8.5 (*)
│   │   │   ├── rustls v0.20.7 (*)
│   │   │   ├── sha-1 v0.10.0
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   ├── cpufeatures v0.2.5
│   │   │   │   └── digest v0.10.5 (*)
│   │   │   ├── thiserror v1.0.37
│   │   │   │   └── thiserror-impl v1.0.37 (proc-macro)
│   │   │   │       ├── proc-macro2 v1.0.47 (*)
│   │   │   │       ├── quote v1.0.21 (*)
│   │   │   │       └── syn v1.0.103 (*)
│   │   │   ├── url v2.3.1 (*)
│   │   │   ├── utf-8 v0.7.6
│   │   │   └── webpki v0.22.0 (*)
│   │   └── webpki v0.22.0 (*)
│   ├── tracing v0.1.37
│   │   ├── cfg-if v1.0.0
│   │   ├── pin-project-lite v0.2.9
│   │   ├── tracing-attributes v0.1.23 (proc-macro)
│   │   │   ├── proc-macro2 v1.0.47 (*)
│   │   │   ├── quote v1.0.21 (*)
│   │   │   └── syn v1.0.103 (*)
│   │   └── tracing-core v0.1.30
│   │       └── once_cell v1.16.0
│   ├── twilight-gateway-queue v0.14.0
│   │   ├── tokio v1.21.2 (*)
│   │   └── tracing v0.1.37 (*)
│   ├── twilight-http v0.14.0
│   │   ├── hyper v0.14.23
│   │   │   ├── bytes v1.2.1
│   │   │   ├── futures-channel v0.3.25 (*)
│   │   │   ├── futures-core v0.3.25
│   │   │   ├── futures-util v0.3.25 (*)
│   │   │   ├── h2 v0.3.15
│   │   │   │   ├── bytes v1.2.1
│   │   │   │   ├── fnv v1.0.7
│   │   │   │   ├── futures-core v0.3.25
│   │   │   │   ├── futures-sink v0.3.25
│   │   │   │   ├── futures-util v0.3.25 (*)
│   │   │   │   ├── http v0.2.8 (*)
│   │   │   │   ├── indexmap v1.9.1
│   │   │   │   │   └── hashbrown v0.12.3
│   │   │   │   │   [build-dependencies]
│   │   │   │   │   └── autocfg v1.1.0
│   │   │   │   ├── slab v0.4.7 (*)
│   │   │   │   ├── tokio v1.21.2 (*)
│   │   │   │   ├── tokio-util v0.7.4
│   │   │   │   │   ├── bytes v1.2.1
│   │   │   │   │   ├── futures-core v0.3.25
│   │   │   │   │   ├── futures-sink v0.3.25
│   │   │   │   │   ├── pin-project-lite v0.2.9
│   │   │   │   │   ├── tokio v1.21.2 (*)
│   │   │   │   │   └── tracing v0.1.37 (*)
│   │   │   │   └── tracing v0.1.37 (*)
│   │   │   ├── http v0.2.8 (*)
│   │   │   ├── http-body v0.4.5
│   │   │   │   ├── bytes v1.2.1
│   │   │   │   ├── http v0.2.8 (*)
│   │   │   │   └── pin-project-lite v0.2.9
│   │   │   ├── httparse v1.8.0
│   │   │   ├── httpdate v1.0.2
│   │   │   ├── itoa v1.0.4
│   │   │   ├── pin-project-lite v0.2.9
│   │   │   ├── socket2 v0.4.7 (*)
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   ├── tower-service v0.3.2
│   │   │   ├── tracing v0.1.37 (*)
│   │   │   └── want v0.3.0
│   │   │       ├── log v0.4.17 (*)
│   │   │       └── try-lock v0.2.3
│   │   ├── hyper-rustls v0.23.1
│   │   │   ├── http v0.2.8 (*)
│   │   │   ├── hyper v0.14.23 (*)
│   │   │   ├── rustls v0.20.7 (*)
│   │   │   ├── rustls-native-certs v0.6.2 (*)
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   └── tokio-rustls v0.23.4 (*)
│   │   ├── percent-encoding v2.2.0
│   │   ├── rand v0.8.5 (*)
│   │   ├── serde v1.0.147 (*)
│   │   ├── serde_json v1.0.87 (*)
│   │   ├── tokio v1.21.2 (*)
│   │   ├── tracing v0.1.37 (*)
│   │   ├── twilight-http-ratelimiting v0.14.0
│   │   │   ├── futures-util v0.3.25 (*)
│   │   │   ├── http v0.2.8 (*)
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   └── tracing v0.1.37 (*)
│   │   ├── twilight-model v0.14.0
│   │   │   ├── bitflags v1.3.2
│   │   │   ├── serde v1.0.147 (*)
│   │   │   ├── serde-value v0.7.0
│   │   │   │   ├── ordered-float v2.10.0
│   │   │   │   │   └── num-traits v0.2.15 (*)
│   │   │   │   └── serde v1.0.147 (*)
│   │   │   ├── serde_repr v0.1.9 (proc-macro)
│   │   │   │   ├── proc-macro2 v1.0.47 (*)
│   │   │   │   ├── quote v1.0.21 (*)
│   │   │   │   └── syn v1.0.103 (*)
│   │   │   ├── time v0.3.17 (*)
│   │   │   └── tracing v0.1.37 (*)
│   │   └── twilight-validate v0.14.0
│   │       └── twilight-model v0.14.0 (*)
│   ├── twilight-model v0.14.0 (*)
│   └── url v2.3.1 (*)
├── twilight-http v0.14.0 (*)
├── twilight-model v0.14.0 (*)
└── twilight-util v0.14.0
    ├── twilight-model v0.14.0 (*)
    └── twilight-validate v0.14.0 (*)
</code></pre>
</details>

<details pre>
<summary>
cargo tree after:
</summary>
<pre><code>
roblox-ts-bot v0.1.0
├── anyhow v1.0.66
├── dotenv v0.15.0
├── futures v0.3.25
│   ├── futures-channel v0.3.25
│   │   ├── futures-core v0.3.25
│   │   └── futures-sink v0.3.25
│   ├── futures-core v0.3.25
│   ├── futures-executor v0.3.25
│   │   ├── futures-core v0.3.25
│   │   ├── futures-task v0.3.25
│   │   └── futures-util v0.3.25
│   │       ├── futures-channel v0.3.25 (*)
│   │       ├── futures-core v0.3.25
│   │       ├── futures-io v0.3.25
│   │       ├── futures-macro v0.3.25 (proc-macro)
│   │       │   ├── proc-macro2 v1.0.47
│   │       │   │   └── unicode-ident v1.0.5
│   │       │   ├── quote v1.0.21
│   │       │   │   └── proc-macro2 v1.0.47 (*)
│   │       │   └── syn v1.0.103
│   │       │       ├── proc-macro2 v1.0.47 (*)
│   │       │       ├── quote v1.0.21 (*)
│   │       │       └── unicode-ident v1.0.5
│   │       ├── futures-sink v0.3.25
│   │       ├── futures-task v0.3.25
│   │       ├── memchr v2.5.0
│   │       ├── pin-project-lite v0.2.9
│   │       ├── pin-utils v0.1.0
│   │       └── slab v0.4.7
│   │           [build-dependencies]
│   │           └── autocfg v1.1.0
│   ├── futures-io v0.3.25
│   ├── futures-sink v0.3.25
│   ├── futures-task v0.3.25
│   └── futures-util v0.3.25 (*)
├── hyper v0.14.23
│   ├── bytes v1.2.1
│   ├── futures-channel v0.3.25 (*)
│   ├── futures-core v0.3.25
│   ├── futures-util v0.3.25 (*)
│   ├── h2 v0.3.15
│   │   ├── bytes v1.2.1
│   │   ├── fnv v1.0.7
│   │   ├── futures-core v0.3.25
│   │   ├── futures-sink v0.3.25
│   │   ├── futures-util v0.3.25 (*)
│   │   ├── http v0.2.8
│   │   │   ├── bytes v1.2.1
│   │   │   ├── fnv v1.0.7
│   │   │   └── itoa v1.0.4
│   │   ├── indexmap v1.9.1
│   │   │   └── hashbrown v0.12.3
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.1.0
│   │   ├── slab v0.4.7 (*)
│   │   ├── tokio v1.21.2
│   │   │   ├── bytes v1.2.1
│   │   │   ├── libc v0.2.137
│   │   │   ├── memchr v2.5.0
│   │   │   ├── mio v0.8.5
│   │   │   │   ├── libc v0.2.137
│   │   │   │   └── log v0.4.17
│   │   │   │       └── cfg-if v1.0.0
│   │   │   ├── num_cpus v1.14.0
│   │   │   │   └── libc v0.2.137
│   │   │   ├── parking_lot v0.12.1
│   │   │   │   ├── lock_api v0.4.9
│   │   │   │   │   └── scopeguard v1.1.0
│   │   │   │   │   [build-dependencies]
│   │   │   │   │   └── autocfg v1.1.0
│   │   │   │   └── parking_lot_core v0.9.4
│   │   │   │       ├── cfg-if v1.0.0
│   │   │   │       ├── libc v0.2.137
│   │   │   │       └── smallvec v1.10.0
│   │   │   ├── pin-project-lite v0.2.9
│   │   │   ├── signal-hook-registry v1.4.0
│   │   │   │   └── libc v0.2.137
│   │   │   ├── socket2 v0.4.7
│   │   │   │   └── libc v0.2.137
│   │   │   └── tokio-macros v1.8.0 (proc-macro)
│   │   │       ├── proc-macro2 v1.0.47 (*)
│   │   │       ├── quote v1.0.21 (*)
│   │   │       └── syn v1.0.103 (*)
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.1.0
│   │   ├── tokio-util v0.7.4
│   │   │   ├── bytes v1.2.1
│   │   │   ├── futures-core v0.3.25
│   │   │   ├── futures-sink v0.3.25
│   │   │   ├── pin-project-lite v0.2.9
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   └── tracing v0.1.37
│   │   │       ├── cfg-if v1.0.0
│   │   │       ├── pin-project-lite v0.2.9
│   │   │       ├── tracing-attributes v0.1.23 (proc-macro)
│   │   │       │   ├── proc-macro2 v1.0.47 (*)
│   │   │       │   ├── quote v1.0.21 (*)
│   │   │       │   └── syn v1.0.103 (*)
│   │   │       └── tracing-core v0.1.30
│   │   │           └── once_cell v1.16.0
│   │   └── tracing v0.1.37 (*)
│   ├── http v0.2.8 (*)
│   ├── http-body v0.4.5
│   │   ├── bytes v1.2.1
│   │   ├── http v0.2.8 (*)
│   │   └── pin-project-lite v0.2.9
│   ├── httparse v1.8.0
│   ├── httpdate v1.0.2
│   ├── itoa v1.0.4
│   ├── pin-project-lite v0.2.9
│   ├── socket2 v0.4.7 (*)
│   ├── tokio v1.21.2 (*)
│   ├── tower-service v0.3.2
│   ├── tracing v0.1.37 (*)
│   └── want v0.3.0
│       ├── log v0.4.17 (*)
│       └── try-lock v0.2.3
├── regex v1.7.0
│   ├── aho-corasick v0.7.19
│   │   └── memchr v2.5.0
│   ├── memchr v2.5.0
│   └── regex-syntax v0.6.28
├── tokio v1.21.2 (*)
├── twilight-gateway v0.14.0
│   ├── bitflags v1.3.2
│   ├── futures-util v0.3.25 (*)
│   ├── leaky-bucket-lite v0.5.2
│   │   └── tokio v1.21.2 (*)
│   ├── rustls v0.20.7
│   │   ├── log v0.4.17 (*)
│   │   ├── ring v0.16.20
│   │   │   ├── libc v0.2.137
│   │   │   ├── once_cell v1.16.0
│   │   │   ├── spin v0.5.2
│   │   │   └── untrusted v0.7.1
│   │   │   [build-dependencies]
│   │   │   └── cc v1.0.76
│   │   ├── sct v0.7.0
│   │   │   ├── ring v0.16.20 (*)
│   │   │   └── untrusted v0.7.1
│   │   └── webpki v0.22.0
│   │       ├── ring v0.16.20 (*)
│   │       └── untrusted v0.7.1
│   ├── rustls-native-certs v0.6.2
│   │   ├── openssl-probe v0.1.5
│   │   └── rustls-pemfile v1.0.1
│   │       └── base64 v0.13.1
│   ├── serde v1.0.147
│   │   └── serde_derive v1.0.147 (proc-macro)
│   │       ├── proc-macro2 v1.0.47 (*)
│   │       ├── quote v1.0.21 (*)
│   │       └── syn v1.0.103 (*)
│   ├── serde_json v1.0.87
│   │   ├── itoa v1.0.4
│   │   ├── ryu v1.0.11
│   │   └── serde v1.0.147 (*)
│   ├── tokio v1.21.2 (*)
│   ├── tokio-tungstenite v0.17.2
│   │   ├── futures-util v0.3.25 (*)
│   │   ├── log v0.4.17 (*)
│   │   ├── rustls v0.20.7 (*)
│   │   ├── rustls-native-certs v0.6.2 (*)
│   │   ├── tokio v1.21.2 (*)
│   │   ├── tokio-rustls v0.23.4
│   │   │   ├── rustls v0.20.7 (*)
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   └── webpki v0.22.0 (*)
│   │   ├── tungstenite v0.17.3
│   │   │   ├── base64 v0.13.1
│   │   │   ├── byteorder v1.4.3
│   │   │   ├── bytes v1.2.1
│   │   │   ├── http v0.2.8 (*)
│   │   │   ├── httparse v1.8.0
│   │   │   ├── log v0.4.17 (*)
│   │   │   ├── rand v0.8.5
│   │   │   │   ├── libc v0.2.137
│   │   │   │   ├── rand_chacha v0.3.1
│   │   │   │   │   ├── ppv-lite86 v0.2.17
│   │   │   │   │   └── rand_core v0.6.4
│   │   │   │   │       └── getrandom v0.2.8
│   │   │   │   │           ├── cfg-if v1.0.0
│   │   │   │   │           └── libc v0.2.137
│   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   ├── rustls v0.20.7 (*)
│   │   │   ├── sha-1 v0.10.0
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   ├── cpufeatures v0.2.5
│   │   │   │   └── digest v0.10.5
│   │   │   │       ├── block-buffer v0.10.3
│   │   │   │       │   └── generic-array v0.14.6
│   │   │   │       │       └── typenum v1.15.0
│   │   │   │       │       [build-dependencies]
│   │   │   │       │       └── version_check v0.9.4
│   │   │   │       └── crypto-common v0.1.6
│   │   │   │           ├── generic-array v0.14.6 (*)
│   │   │   │           └── typenum v1.15.0
│   │   │   ├── thiserror v1.0.37
│   │   │   │   └── thiserror-impl v1.0.37 (proc-macro)
│   │   │   │       ├── proc-macro2 v1.0.47 (*)
│   │   │   │       ├── quote v1.0.21 (*)
│   │   │   │       └── syn v1.0.103 (*)
│   │   │   ├── url v2.3.1
│   │   │   │   ├── form_urlencoded v1.1.0
│   │   │   │   │   └── percent-encoding v2.2.0
│   │   │   │   ├── idna v0.3.0
│   │   │   │   │   ├── unicode-bidi v0.3.8
│   │   │   │   │   └── unicode-normalization v0.1.22
│   │   │   │   │       └── tinyvec v1.6.0
│   │   │   │   │           └── tinyvec_macros v0.1.0
│   │   │   │   └── percent-encoding v2.2.0
│   │   │   ├── utf-8 v0.7.6
│   │   │   └── webpki v0.22.0 (*)
│   │   └── webpki v0.22.0 (*)
│   ├── tracing v0.1.37 (*)
│   ├── twilight-gateway-queue v0.14.0
│   │   ├── tokio v1.21.2 (*)
│   │   └── tracing v0.1.37 (*)
│   ├── twilight-http v0.14.0
│   │   ├── hyper v0.14.23 (*)
│   │   ├── hyper-rustls v0.23.1
│   │   │   ├── http v0.2.8 (*)
│   │   │   ├── hyper v0.14.23 (*)
│   │   │   ├── rustls v0.20.7 (*)
│   │   │   ├── rustls-native-certs v0.6.2 (*)
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   └── tokio-rustls v0.23.4 (*)
│   │   ├── percent-encoding v2.2.0
│   │   ├── rand v0.8.5 (*)
│   │   ├── serde v1.0.147 (*)
│   │   ├── serde_json v1.0.87 (*)
│   │   ├── tokio v1.21.2 (*)
│   │   ├── tracing v0.1.37 (*)
│   │   ├── twilight-http-ratelimiting v0.14.0
│   │   │   ├── futures-util v0.3.25 (*)
│   │   │   ├── http v0.2.8 (*)
│   │   │   ├── tokio v1.21.2 (*)
│   │   │   └── tracing v0.1.37 (*)
│   │   ├── twilight-model v0.14.0
│   │   │   ├── bitflags v1.3.2
│   │   │   ├── serde v1.0.147 (*)
│   │   │   ├── serde-value v0.7.0
│   │   │   │   ├── ordered-float v2.10.0
│   │   │   │   │   └── num-traits v0.2.15
│   │   │   │   │       [build-dependencies]
│   │   │   │   │       └── autocfg v1.1.0
│   │   │   │   └── serde v1.0.147 (*)
│   │   │   ├── serde_repr v0.1.9 (proc-macro)
│   │   │   │   ├── proc-macro2 v1.0.47 (*)
│   │   │   │   ├── quote v1.0.21 (*)
│   │   │   │   └── syn v1.0.103 (*)
│   │   │   ├── time v0.3.17
│   │   │   │   └── time-core v0.1.0
│   │   │   └── tracing v0.1.37 (*)
│   │   └── twilight-validate v0.14.0
│   │       └── twilight-model v0.14.0 (*)
│   ├── twilight-model v0.14.0 (*)
│   └── url v2.3.1 (*)
├── twilight-http v0.14.0 (*)
├── twilight-model v0.14.0 (*)
└── twilight-util v0.14.0
    ├── twilight-model v0.14.0 (*)
    └── twilight-validate v0.14.0 (*)

</code></pre>
</details>

This is approximately 40 less dependencies to build, and hyper was already depended on by `twilight-http`.
Running the docker build before gives me `198.6s` compile times, while after yields `178.4s`, slightly faster.