### PR TITLE
Fix missing toolchain override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
 
     - name: Build
       run: cargo build --locked
@@ -35,7 +33,6 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
         components: rustfmt, clippy
 
     - name: Rustfmt

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-06-15"


### PR DESCRIPTION
Necessary for `thiserror` @ `1.0.37`, which uses the feature `proc_macro_span_shrink`.