### PR TITLE
Skip tagging archived threads

### DIFF
--- a/src/jobs/processThread.ts
+++ b/src/jobs/processThread.ts
@@ -8,6 +8,8 @@ export async function processThread(channel: Discord.AnyThreadChannel) {
 	// force fetch latest data (including tags)
 	channel = await channel.fetch();
 
+	if (channel.archived) return;
+
 	const hasSolved = channel.appliedTags.includes(SOLVED_TAG_ID);
 	const hasUnsolved = channel.appliedTags.includes(UNSOLVED_TAG_ID);
 


### PR DESCRIPTION
## Summary
- prevent the bot from tagging archived help threads as unsolved to avoid crashes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e073da818832c8c80a1b9718b686f)